### PR TITLE
move ecmaFeatures into parserOptions

### DIFF
--- a/rules/shared/react-a11y.js
+++ b/rules/shared/react-a11y.js
@@ -3,8 +3,10 @@ module.exports = {
     'jsx-a11y',
     'react'
   ],
-  ecmaFeatures: {
-    jsx: true
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    }
   },
   rules: {
     // Enforce that anchors have content

--- a/rules/shared/react.js
+++ b/rules/shared/react.js
@@ -7,9 +7,6 @@ module.exports = {
       jsx: true
     }
   },
-  ecmaFeatures: {
-    jsx: true
-  },
 
   // View link below for react rules documentation
   // https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules


### PR DESCRIPTION
When upgrading a project to use eslint@4.1.0 I was getting an error "unexpected top-level property ecmafeatures"