### PR TITLE
Add rule for arrow function parens

### DIFF
--- a/rules/node-es6.js
+++ b/rules/node-es6.js
@@ -36,6 +36,7 @@ module.exports = {
         'no-debugger': 0,
         'spaced-comment': 0,
         'no-console': 0,
-        'no-alert': 0
+        'no-alert': 0,
+        'arrow-parens':['error', 'as-needed']
     }
 };

--- a/rules/node-strict.js
+++ b/rules/node-strict.js
@@ -35,6 +35,7 @@ module.exports = {
         'no-debugger': 0,
         'spaced-comment': 0,
         'no-console': 0,
-        'no-alert': 0
+        'no-alert': 0,
+        'arrow-parens':['error', 'as-needed']
     }
 };


### PR DESCRIPTION
This rule enforces a rule on the **fat arrow** function parentheses. I feel it is necessary to have this rule since the `(x) => {...}` function can also be written `x => {...}`, and I'm seeing them mixed in both ways.

The rule I added will enforce the removal of the parens with a single argument. https://eslint.org/docs/rules/arrow-parens#as-needed

I like my arrow functions this way, especially for promise chains. 
``` javascript 
PinkyPromise
  .then(pinkyPromiseResult => {...})
  .then(nextResult => {...})
  .catch(err => {...});
```

However it can go either way. The rule can also be written `'arrow-parens': ['error', 'always']` to enforce always using parens. I believe one of these two: `always` or `as-needed`  should be added. My vote is `as-needed`. 