### PR TITLE
change arrow return and camelcase rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cbtnuggets",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Base eslint configuration for cbtnuggets",
   "main": "index.js",
   "private": false,

--- a/rules/node-es6.js
+++ b/rules/node-es6.js
@@ -37,6 +37,8 @@ module.exports = {
         'spaced-comment': 0,
         'no-console': 0,
         'no-alert': 0,
-        'arrow-parens':['error', 'as-needed']
+        'arrow-parens':['error', 'as-needed'],
+        'arrow-body-style': 'off',
+        'camelcase': 'warn'
     }
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -51,6 +51,8 @@ module.exports = {
         'no-debugger': 0,
         'spaced-comment': 0,
         'no-console': 0,
-        'no-alert': 0
+        'no-alert': 0,
+        'arrow-body-style': 'off',
+        'camelcase': 'warn'
     }
 };


### PR DESCRIPTION
- explicitly returning inside es6 function brackets is ok

- changed error to a warning for camelcase in object