### PR TITLE
Milton updates

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exit 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-config-cbtnuggets",
-  "version": "8.0.0",
+  "name": "@cbtnuggets/eslint-config-cbtnuggets",
+  "version": "8.1.0",
   "description": "Base eslint configuration for cbtnuggets",
   "main": "index.js",
   "private": false,


### PR DESCRIPTION
Finishing updates into npmjs.org registry.
- deleted build/build.sh used for jenkins
- bumped version
- changed name to include scope "@cbtnuggets"

Note: metadata.yaml already added.