### PR TITLE
Fix deprecation warning, publish to npmjs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "env": {
+        "node": true,
+        "es6": true,
+        "browser": true,
+        "mocha": true
+    },
+    "extends": "eslint-config-cbtnuggets/rules/node-es6",
+}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,2 @@
-# This file contains information about the repo
-# library name, the name of the job that publishes, etc.
-buildEngine: "node-6.9.1"
 type: library
-deployMethod: publish
+buildEngine: node-8.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-config-cbtnuggets",
-  "version": "8.1.1",
+  "name": "@cbtnuggets/eslint-config-cbtnuggets",
+  "version": "8.2.0",
   "description": "Base eslint configuration for CBT Nuggets",
   "main": "index.js",
   "private": false,
@@ -10,9 +10,7 @@
     "url": "https://github.com/cbtnuggets/eslint-config-cbtnuggets.git"
   },
   "scripts": {
-    "test": "exit",
-    "build": "exit",
-    "lint": "exit"
+    "lint": "eslint ."
   },
   "author": "",
   "homepage": "https://github.com/cbtnuggets/eslint-config-cbtnuggets",

--- a/rules/node-es6.js
+++ b/rules/node-es6.js
@@ -12,19 +12,16 @@ module.exports = {
         './shared/variables'
     ].map(require.resolve),
     parserOptions: {
-        ecmaFeatures: {
-            experimentalObjectRestSpread: true
-        },
-        ecmaVersion: 7,
+        ecmaVersion: 2017,
         sourceType: 'module'
     },
     plugins: [
         'class-property'
     ],
     rules: {
-        'quotes': [2, 'single'],
-        'strict': [2, 'never'],
-        'indent': 0,
+        quotes: [2, 'single'],
+        strict: [2, 'never'],
+        indent: 0,
         'no-trailing-spaces': 0,
         'import/prefer-default-export': 0,
         'id-length': 0,
@@ -38,6 +35,6 @@ module.exports = {
         'no-console': 0,
         'no-alert': 0,
         'arrow-body-style': 'off',
-        'camelcase': 'warn'
+        camelcase: 'warn'
     }
 };

--- a/rules/node-strict.js
+++ b/rules/node-strict.js
@@ -11,19 +11,16 @@ module.exports = {
         './shared/variables'
     ].map(require.resolve),
     parserOptions: {
-        ecmaFeatures: {
-            experimentalObjectRestSpread: true
-        },
-        ecmaVersion: 7,
+        ecmaVersion: 2017,
         sourceType: 'module'
     },
     plugins: [
         'class-property'
     ],
     rules: {
-        'quotes': [2, 'single'],
-        'strict': [0, 'global'],
-        'indent': 0,
+        quotes: [2, 'single'],
+        strict: [0, 'global'],
+        indent: 0,
         'no-trailing-spaces': 0,
         'import/prefer-default-export': 0,
         'id-length': 0,

--- a/rules/node.js
+++ b/rules/node.js
@@ -7,106 +7,104 @@
 // For more info just google "eslint" and the name of the rule
 //    or view the ESLint rules documentation: http://eslint.org/docs/rules/
 module.exports = {
-    "env": {
-        "node": true
+    env: {
+        node: true
     },
-    "rules": {
+    rules: {
         //
         // Disabled rules
         //
-        // Allow console.log
-        "no-console": 0,
         // Disallow unused variables
-        "no-unused-vars": 0,
+        'no-unused-vars': 0,
 
         //
         // Errors
         //
         // Disallow use of variables before they are defined, except for functions
-        "no-use-before-define": [2, "nofunc"],
+        'no-use-before-define': [2, 'nofunc'],
         // Disallow spacing inside array brackets
-        "array-bracket-spacing": [2, "never"],
+        'array-bracket-spacing': [2, 'never'],
         // Disallow variable usage outside the scope they were defined in. Emulates c-style scoping
-        "block-scoped-var": 2,
+        'block-scoped-var': 2,
         // Enforce One true brace style. Also allow all braces on a single line.
-        "brace-style": [2, "1tbs", {"allowSingleLine": true}],
+        'brace-style': [2, '1tbs', { allowSingleLine: true }],
         // Allow a return before a callback is called
-        "callback-return": 0,
+        'callback-return': 0,
         // Disallow underscores in variables. Property names are not checked. All uppercase variables are not checked.
-        "camelcase": [2, {"properties": "never"}],
+        camelcase: [2, { properties: 'never' }],
         // Enforce spacing around commas. No space before commas, require space after commas.
-        "comma-spacing": [2, {"before": false, "after": true}],
+        'comma-spacing': [2, { before: false, after: true }],
         // Enforce that a comma appears after a variable, array element, or property definition on the same line and not the next line
-        "comma-style": [2, "last"],
+        'comma-style': [2, 'last'],
         // Disallow spaces inside computed properties, obj[foo] instead of obj[ foo ]
-        "computed-property-spacing": [2, "never"],
+        'computed-property-spacing': [2, 'never'],
         // Enforce curly braces with if, while, and for loops
-        "curly": 2,
+        curly: 2,
         // Enforce a dot on the same line as a property, not the line with the object on it
-        "dot-location": [2, "property"],
+        'dot-location': [2, 'property'],
         // Enforce that the file ends with a single newline, no trailing newlines
-        "eol-last": 2,
+        'eol-last': 2,
         // Enforce the use of === and !== except for comparing literal values, typeof, and comparing to null
-        "eqeqeq": [2, "smart"],
+        eqeqeq: [2, 'smart'],
         // Enforce 4 space indention, including switch cases
-        "indent": [2, 4, {"SwitchCase": 1}],
+        indent: [2, 4, { SwitchCase: 1 }],
         // Enforce no space before a colon, require exactly one space after a colon in an object property definition
-        "key-spacing": [2, {"beforeColon": false, "afterColon": true, "mode": "strict"}],
+        'key-spacing': [2, { beforeColon: false, afterColon: true, mode: 'strict' }],
         // Disallow array construction with 'new'
-        "no-array-constructor": 2,
+        'no-array-constructor': 2,
         // Warning if a console is left in code
-        "no-console": 1,
+        'no-console': 1,
         // Disallow extending native objects
-        "no-extend-native": 2,
+        'no-extend-native': 2,
         // Disallow spacing and tabs for indention
-        "no-mixed-spaces-and-tabs": 2,
+        'no-mixed-spaces-and-tabs': 2,
         // Disallow more than two consecutive empty lines in a source file
-        "no-multiple-empty-lines": [2, {"max": 2}],
+        'no-multiple-empty-lines': [2, { max: 2 }],
         // Disallow object construction with new
-        "no-new-object": 2,
+        'no-new-object': 2,
         // Disallow spaces between the function name and the open parenthesis
-        "no-spaced-func": 2,
+        'no-spaced-func': 2,
         // Disallow spaces at the end of lines
-        "no-trailing-spaces": 2,
+        'no-trailing-spaces': 2,
         // Disallow spaces before or after curly braces inside object literals
-        "object-curly-spacing": [2, "never"],
+        'object-curly-spacing': [2, 'never'],
         // Disallow empty lines at the start or end of blocks
-        "padded-blocks": [2, "never"],
+        'padded-blocks': [2, 'never'],
         // Enforce the use of single quotes for strings, unless the string contains single quotes
-        "quotes": [2, "single", "avoid-escape"],
+        quotes: [2, 'single', 'avoid-escape'],
         // Enforce semi-colons at the end of all statements
-        "semi": [2, "always"],
+        semi: [2, 'always'],
         // This rule enforces consistent spacing around keywords and keyword-like tokens if, else, for, while, do, switch, try, catch, finally, and with.
-        "keyword-spacing": [2, {"before": true, "after": true}],
+        'keyword-spacing': [2, { before: true, after: true }],
         // Enforce a space before the opening brace of a block
-        "space-before-blocks": [2, "always"],
+        'space-before-blocks': [2, 'always'],
         // Enforce a space before anonymous functions opening paren, disallow a space before a named function opening paren
-        "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
+        'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
         // Disallowing spaces to the right of ( and to the left of )
-        "space-in-parens": [2, "never"],
+        'space-in-parens': [2, 'never'],
         // Require space on either side of an operator
-        "space-infix-ops": 2,
+        'space-infix-ops': 2,
         // Enforce spaces after unary word operators such as: new, delete, typeof, void, yield
         // Disallow spaces before or after no-word unary ops like  -, +, --, ++, !, !!
-        "space-unary-ops": [2, {"words": true, "nonwords": false}],
+        'space-unary-ops': [2, { words: true, nonwords: false }],
         // Enforce whitespace after a comment character except when starting with -,+ or a marker at the beginning of a comment
-        "spaced-comment": [2, "always", {"exceptions": ["-", "+"], "markers": ["=", "!"]}],
+        'spaced-comment': [2, 'always', { exceptions: ['-', '+'], markers: ['=', '!'] }],
         // Enforce strict at the global level. It cannot be used inside functions
-        "strict": [2, "global"],
+        strict: [2, 'global'],
 
         //
         // Warnings
         //
         // Warn if new keywords are not followed by an uppercase, or uppercase functions are not preceded by a new. Do not check properties
-        "new-cap": [1, {"newIsCap": true, "capIsNew": false, "properties": false}],
+        'new-cap': [1, { newIsCap: true, capIsNew: false, properties: false }],
         // Warn if blocks are nested more than 3 levels deep
-        "max-depth": [1, 3],
+        'max-depth': [1, 3],
         // Warn if there are more than 30 statements in a function
-        "max-statements": [1, 30],
+        'max-statements': [1, 30],
         // Warn if lines are longer than 160 characters
-        "max-len": [1, 160]
+        'max-len': [1, 160]
     },
-    "extends": [
-      "eslint:recommended"
+    extends: [
+      'eslint:recommended'
     ]
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -15,22 +15,19 @@ module.exports = {
         './shared/variables'
     ].map(require.resolve),
     parserOptions: {
-        ecmaFeatures: {
-            experimentalObjectRestSpread: true
-        },
-        ecmaVersion: 7,
+        ecmaVersion: 2017,
         sourceType: 'module'
     },
     plugins: [
         'class-property'
     ],
     rules: {
-        'quotes': [1, 'single'],
-        'strict': [1, 'never'],
-        'indent': 1,
+        quotes: [1, 'single'],
+        strict: [1, 'never'],
+        indent: 1,
         'no-trailing-spaces': 1,
         'arrow-body-style': 'off',
-        'camelcase': 'warn',
+        camelcase: 'warn',
         'import/prefer-default-export': 'warn',
         'import/no-named-as-default': 'warn',
         'no-mixed-operators': 'warn',

--- a/rules/shared/react-a11y.js
+++ b/rules/shared/react-a11y.js
@@ -50,7 +50,7 @@ module.exports = {
 
     // require that JSX labels use "htmlFor"
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-    'jsx-a11y/label-has-for': [2, {components: ['label']}],
+    'jsx-a11y/label-has-for': [2, { components: ['label'] }],
 
     // require that mouseover/out come with focus/blur, for keyboard-only users
     // TODO: evaluate

--- a/rules/shared/react.js
+++ b/rules/shared/react.js
@@ -37,7 +37,7 @@ module.exports = {
 
     // Limit maximum of props on a single line in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
-    'react/jsx-max-props-per-line': [1, { "when": "multiline" }],
+    'react/jsx-max-props-per-line': [1, { when: 'multiline' }],
 
     // Prevent usage of .bind() in JSX props
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

--- a/rules/shared/style.js
+++ b/rules/shared/style.js
@@ -11,7 +11,7 @@ module.exports = {
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
 
     // require camel case names
-    'camelcase': ['error', { properties: 'never' }],
+    camelcase: ['error', { properties: 'never' }],
 
     // enforce spacing before and after comma
     'comma-spacing': ['error', { before: false, after: true }],
@@ -297,7 +297,7 @@ module.exports = {
     // require or disallow a space immediately following the // or /* in a comment
     'spaced-comment': ['error', 'always', {
       exceptions: ['-', '+'],
-      markers: ['=', '!']           // space here to support sprockets directives
+      markers: ['=', '!'] // space here to support sprockets directives
     }],
 
     // require or disallow the Unicode Byte Order Mark


### PR DESCRIPTION
This PR includes several changes:

1. Fixes DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "eslint-config-cbtnuggets/rules/node-es6")
2. Ran `eslint --fix` to fix many eslint errors in this lib.
3. Fixes `npm run lint` build step to prevent errors from creeping back in.
4. The eslint docs say that `ecmaVersion: 2017` === `ecmaVersion: 7` but using just 7 throws errors on arrow functions.  Seems to work fine on 2017 though.
5. Publishes this lib to newer npmjs registry.

I welcome any feedback or concerns.